### PR TITLE
Add Ardenwood Historic Farm in Fremont

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@
 - Berkeley: 
   - [Adventure Playground](https://www.cityofberkeley.info/adventureplayground)
   - [Tilden Park Merry Go Round](http://www.tildenmerrygoround.org/)
+- Fremont
+  - [Ardenwood Historic Farm](https://www.ebparks.org/parks/ardenwood/)
 - Oakland: 
   - [Children's Fairyland](http://fairyland.org/) 
   - [Frog Park](https://www.frogpark.org/) 


### PR DESCRIPTION
Add Ardenwood Historic Farm in Fremont. It's similar to Emma Prusch, but they have a train you can ride and way more barnyard animals.